### PR TITLE
Add Jest tests for shuffle function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # chagoo.github.io
+
+This repository contains the source for the site and small JavaScript challenges.
+
+## Running Tests
+
+The project uses [Jest](https://jestjs.io/) for unit testing. To install dependencies and run the tests:
+
+```bash
+npm install
+npm test
+```
+
+The tests are located under the `tests/` directory.

--- a/challenge5.js
+++ b/challenge5.js
@@ -1,4 +1,17 @@
-document.addEventListener('DOMContentLoaded', () => { 
+function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = shuffle;
+}
+
+if (typeof document !== 'undefined') {
+document.addEventListener('DOMContentLoaded', () => {
     let shuffledCards = [];
     let firstCard = null;
     let secondCard = null;
@@ -22,12 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
             .catch(error => console.error('Error fetching words:', error));
     }
 
-    function shuffle(array) {
-        for (let i = array.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [array[i], array[j]] = [array[j], array[i]];
-        }
-    }
+
 
     function createCard(word, language, pair) {
         const card = document.createElement('div');
@@ -138,3 +146,4 @@ document.addEventListener('DOMContentLoaded', () => {
     restartButton.addEventListener('click', fetchWords);
     fetchWords();
 });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chagoo.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "challenge1.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/challenge5.test.js
+++ b/tests/challenge5.test.js
@@ -1,0 +1,11 @@
+const shuffle = require('../challenge5');
+
+test('shuffle returns array with same length and elements', () => {
+  const input = [1, 2, 3, 4, 5];
+  const copy = [...input];
+  const result = shuffle(copy);
+  // same length
+  expect(result.length).toBe(input.length);
+  // same elements (ignoring order)
+  expect(result.sort()).toEqual([...input].sort());
+});


### PR DESCRIPTION
## Summary
- export `shuffle` from `challenge5.js` for testing
- wrap DOM code in `challenge5.js` so it can be required in Node
- add Jest unit test verifying `shuffle` keeps length and elements
- add `package.json` with test script
- document how to run tests in `README.md`

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f85753500833183e400364267f8a6