### PR TITLE
Fix letter button disabling logic

### DIFF
--- a/hangman.js
+++ b/hangman.js
@@ -50,7 +50,12 @@ document.addEventListener('DOMContentLoaded', () => {
     // Handle letter guesses
     function guessLetter(letter) {
         guessedLetters.push(letter);
-        document.querySelector(`button:contains(${letter})`).disabled = true;
+        const buttons = lettersContainer.querySelectorAll('button');
+        buttons.forEach(btn => {
+            if (btn.textContent === letter) {
+                btn.disabled = true;
+            }
+        });
 
         if (selectedWord.includes(letter)) {
             displayWord();


### PR DESCRIPTION
## Summary
- disable guessed letter button by iterating over letter buttons

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f82a467ac833195a96e039fcf5121