### PR TITLE
Fix word list object in menu.js

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
+const wordLists = {
 list29: [
         { "english": "distance", "spanish": "distancia", "definition": "the amount of space between two points" },
         { "english": "distant", "spanish": "distante", "definition": "far away in space or time" },


### PR DESCRIPTION
## Summary
- initialize `wordLists` object inside `menu.js`
- keep existing references for displaying and storing lists

## Testing
- `npm install`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd0f857cc83318f6b7375a7b07d39