### PR TITLE
Add Jest test for createIncompleteWord

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ npm install
 npm test
 ```
 
-The tests are located under the `tests/` directory.
+The tests are located under the `tests/` directory and cover helper functions
+from the various challenge scripts such as `createIncompleteWord` and `shuffle`.

--- a/challenge2.js
+++ b/challenge2.js
@@ -1,3 +1,12 @@
+function createIncompleteWord(word) {
+    return word.split('').map(char => (Math.random() > 0.5 ? '_' : char)).join('');
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { createIncompleteWord };
+}
+
+if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', () => {
     let currentIndex = 0;
     let words = []; // This will hold the fetched word list
@@ -22,10 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
         speechSynthesis.speak(utterance);
     }
 
-    // Function to create an incomplete word by replacing random characters with '_'
-    function createIncompleteWord(word) {
-        return word.split('').map(char => (Math.random() > 0.5 ? '_' : char)).join('');
-    }
+
 
     // Function to create word cards and add them to the carousel
     function createWordCards() {
@@ -129,3 +135,4 @@ document.addEventListener('DOMContentLoaded', () => {
         })
         .catch(error => console.error('Error loading word list:', error));
 });
+}

--- a/tests/challenge2.test.js
+++ b/tests/challenge2.test.js
@@ -1,0 +1,8 @@
+const { createIncompleteWord } = require('../challenge2');
+
+test('createIncompleteWord returns string of same length with underscores or original letters', () => {
+  const word = 'testing';
+  const result = createIncompleteWord(word);
+  expect(result).toHaveLength(word.length);
+  expect(result.split('').every((ch, idx) => ch === '_' || ch === word[idx])).toBe(true);
+});


### PR DESCRIPTION
## Summary
- export `createIncompleteWord` from `challenge2.js`
- add unit test for that helper
- document tests in the README

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd6008c44833194799704892533dd