### PR TITLE
Add highlight to matching game

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -181,3 +181,23 @@ h1 {
 .menu-button:hover {
     background-color: #555; /* Darken button on hover */
 }
+
+/* Highlighting for the matching game */
+.word, .translation {
+    display: inline-block;
+    margin: 5px;
+    padding: 8px 12px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.word.selected, .translation.selected {
+    background-color: #ffff99; /* Highlight selected pair */
+}
+
+.word.correct, .translation.correct {
+    background-color: #c8e6c9; /* Indicate a correct match */
+    border-color: #a5d6a7;
+    cursor: default;
+}


### PR DESCRIPTION
## Summary
- highlight selected words in the word-matching game

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407d24f4b083319aac3a44d21b4776