### PR TITLE
Add cross-challenge scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ from the various challenge scripts such as `createIncompleteWord` and `shuffle`.
 
 The `matching.html` page demonstrates a simple game that pairs English words with their Spanish translations using `script_1.js`. Open the file in your browser and select a word and its translation, then click **Check Answer** to see if they match. Use the **Reset Game** button to start over.
 
+## Scoring and Achievements
+
+All challenges now share a common scoring system powered by `scoreboard.js`. Correct answers or successful matches award points that persist in `localStorage`. When you return to `menu.html`, your accumulated scores are displayed under **Achievements** so you can track progress across the various games.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/challenge1.html
+++ b/challenge1.html
@@ -30,6 +30,7 @@
         <div id="finish-message"></div>
     </div>
 
+    <script src="scoreboard.js"></script>
     <script src="challenge1.js"></script>
 </body>
 </html>

--- a/challenge1.js
+++ b/challenge1.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     const carousel = document.getElementById('carousel');
     const prevBtn = document.getElementById('prev-btn');
     const nextBtn = document.getElementById('next-btn');

--- a/challenge2.html
+++ b/challenge2.html
@@ -39,6 +39,7 @@
     </div>
 
     <!-- Include the JS for this challenge -->
+    <script src="scoreboard.js"></script>
     <script src="challenge2.js"></script>
 </body>
 </html>

--- a/challenge2.js
+++ b/challenge2.js
@@ -8,6 +8,9 @@ if (typeof module !== 'undefined') {
 
 if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     let currentIndex = 0;
     let words = []; // This will hold the fetched word list
 
@@ -100,10 +103,13 @@ document.addEventListener('DOMContentLoaded', () => {
             const userInput = currentCard.querySelector('.word-input').value.trim().toLowerCase();
             const correctAnswer = words[currentIndex].english.toLowerCase();
 
-            if (userInput === correctAnswer) {
-                feedback.innerText = 'Correct! Great job!';
-                feedback.style.color = 'green';
-            } else {
+           if (userInput === correctAnswer) {
+               feedback.innerText = 'Correct! Great job!';
+               feedback.style.color = 'green';
+                if (window.Scoreboard) {
+                    Scoreboard.addScore('challenge2', 1);
+                }
+           } else {
                 feedback.innerText = 'Incorrect. Try again!';
                 feedback.style.color = 'red';
             }

--- a/challenge3.html
+++ b/challenge3.html
@@ -31,6 +31,7 @@
         </div>
     </div>
 
+    <script src="scoreboard.js"></script>
     <script src="challenge3.js"></script>
 </body>
 </html>

--- a/challenge3.js
+++ b/challenge3.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     let words = []; // This will hold the fetched word list
     let currentWord = null;
     let score = 0;
@@ -112,6 +115,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (userTranslation === currentWord.english.toLowerCase()) {
             feedback.innerText = 'Correct!';
             score++;
+            if (window.Scoreboard) {
+                Scoreboard.addScore('challenge3', 1);
+            }
             updateUI();
             loadNextWord();
         } else {

--- a/challenge4.html
+++ b/challenge4.html
@@ -25,6 +25,7 @@
         </div>
     </div>
 
+    <script src="scoreboard.js"></script>
     <script src="challenge4.js"></script>
 </body>
 </html>

--- a/challenge4.js
+++ b/challenge4.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     let words = [];
     let currentWord = null;
 
@@ -78,6 +81,9 @@ document.addEventListener('DOMContentLoaded', () => {
             if (userSpokenWord === currentWord.english.toLowerCase()) {
                 feedback.innerText = 'Correct pronunciation! Well done!';
                 feedback.style.color = 'green';
+                if (window.Scoreboard) {
+                    Scoreboard.addScore('challenge4', 1);
+                }
             } else {
                 feedback.innerText = `Incorrect pronunciation. You said: "${userSpokenWord}". The correct word is: ${currentWord.english}`;
                 feedback.style.color = 'red';

--- a/challenge5.html
+++ b/challenge5.html
@@ -24,6 +24,7 @@
     </div>
 
     <!-- <script src="words.js"></script> -->
+    <script src="scoreboard.js"></script>
     <script src="challenge5.js"></script> <!-- Your main game script -->
     
 </body>

--- a/challenge5.js
+++ b/challenge5.js
@@ -12,6 +12,9 @@ if (typeof module !== 'undefined') {
 
 if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     let shuffledCards = [];
     let firstCard = null;
     let secondCard = null;
@@ -97,6 +100,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Apply explosion effect on both cards when matched
                 firstCard.classList.add('matched');
                 secondCard.classList.add('matched');
+                if (window.Scoreboard) {
+                    Scoreboard.addScore('challenge5', 1);
+                }
                 
                 // Remove the cards from the board after the animation
                 setTimeout(() => {

--- a/hangman.html
+++ b/hangman.html
@@ -37,6 +37,7 @@
         <button id="reset-button">Reset Game</button>
     </div>
 
+    <script src="scoreboard.js"></script>
     <script src="hangman.js"></script>
 </body>
 </html>

--- a/hangman.js
+++ b/hangman.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     const words = ['awesome'];
     let selectedWord;
     let guessedLetters = [];
@@ -31,6 +34,9 @@ document.addEventListener('DOMContentLoaded', () => {
         
         if (!display.includes('_')) {
             message.textContent = 'You Win!';
+            if (window.Scoreboard) {
+                Scoreboard.addScore('hangman', 1);
+            }
             disableButtons();
         }
     }

--- a/matching.html
+++ b/matching.html
@@ -20,6 +20,7 @@
             <a href="menu.html" class="menu-button center-button">Return to Menu</a>
         </div>
     </div>
+    <script src="scoreboard.js"></script>
     <script src="script_1.js"></script>
 </body>
 </html>

--- a/menu.html
+++ b/menu.html
@@ -32,8 +32,11 @@
             <a href="challenge4.html">Go to Challenge 4</a>
             <a href="challenge5.html">Go to Challenge 5</a>
             <a href="matching.html">Play Matching Game</a>
-            
+
         </div>
+
+        <!-- Achievements -->
+        <div id="achievements"></div>
 
         <!-- Modal for word list (Study words) -->
         <div id="word-list-modal" class="modal" style="display: none;">
@@ -45,6 +48,7 @@
         </div>
     </div>
 
+    <script src="scoreboard.js"></script>
     <script src="menu.js"></script>
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,4 +1,17 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+        const achievementsDiv = document.getElementById('achievements');
+        const scores = Scoreboard.getAllScores();
+        achievementsDiv.innerHTML = '<h2>Achievements</h2>';
+        const list = document.createElement('ul');
+        Object.keys(scores).forEach(key => {
+            const li = document.createElement('li');
+            li.innerText = `${key}: ${scores[key]} points`;
+            list.appendChild(li);
+        });
+        achievementsDiv.appendChild(list);
+    }
 const wordLists = {
 list29: [
         { "english": "distance", "spanish": "distancia", "definition": "the amount of space between two points" },

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,0 +1,44 @@
+// Simple Scoreboard stored in localStorage
+const Scoreboard = {
+    scores: {},
+
+    load() {
+        const saved = localStorage.getItem('scores');
+        if (saved) {
+            try {
+                this.scores = JSON.parse(saved);
+            } catch (e) {
+                this.scores = {};
+            }
+        }
+    },
+
+    save() {
+        localStorage.setItem('scores', JSON.stringify(this.scores));
+    },
+
+    addScore(challenge, value = 1) {
+        if (!this.scores[challenge]) {
+            this.scores[challenge] = 0;
+        }
+        this.scores[challenge] += value;
+        this.save();
+    },
+
+    getScore(challenge) {
+        return this.scores[challenge] || 0;
+    },
+
+    getAllScores() {
+        return this.scores;
+    }
+};
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => Scoreboard.load());
+    window.Scoreboard = Scoreboard;
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = Scoreboard;
+}

--- a/script_1.js
+++ b/script_1.js
@@ -28,6 +28,9 @@ const words = [
 ];
 
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Scoreboard) {
+        Scoreboard.load();
+    }
     const wordContainer = document.getElementById('word-container');
     const translationContainer = document.getElementById('translation-container');
     const feedback = document.getElementById('feedback');
@@ -110,6 +113,9 @@ document.addEventListener('DOMContentLoaded', () => {
     function incrementScore() {
         score++;
         scoreElement.innerText = `Score: ${score}`;
+        if (window.Scoreboard) {
+            Scoreboard.addScore('matching', 1);
+        }
     }
 
     function markCorrectMatch() {


### PR DESCRIPTION
## Summary
- add new `scoreboard.js` for persistent scores
- load and update scores from challenges
- show achievements in the menu using stored scores
- document the new scoring system in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840952e06ac8331b2291ef36d0522bb