### PR TITLE
Move menu word lists to JSON

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -12,100 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         achievementsDiv.appendChild(list);
     }
-const wordLists = {
-list29: [
-        { "english": "distance", "spanish": "distancia", "definition": "the amount of space between two points" },
-        { "english": "distant", "spanish": "distante", "definition": "far away in space or time" },
-        { "english": "obedience", "spanish": "obediencia", "definition": "the act of following orders or rules" },
-        { "english": "obedient", "spanish": "obediente", "definition": "willing to follow commands or authority" },
-        { "english": "diligence", "spanish": "diligencia", "definition": "careful and persistent work or effort" },
-        { "english": "diligent", "spanish": "diligente", "definition": "showing careful and persistent effort" },
-        { "english": "importance", "spanish": "importancia", "definition": "the state or fact of being significant or valuable" },
-        { "english": "important", "spanish": "importante", "definition": "having great value or significance" }
-    ],
-    list17: 
-[
-    { "english": "closely", "spanish": "de cerca", "definition": "in a close manner or with attention" },
-    { "english": "delightful", "spanish": "delicioso", "definition": "giving great pleasure or happiness" },
-    { "english": "beginner", "spanish": "principiante", "definition": "someone who is just starting to learn or do something" },
-    { "english": "narrator", "spanish": "narrador", "definition": "a person who tells a story" },
-    { "english": "cheerful", "spanish": "alegre", "definition": "having a happy and positive attitude" },
-    { "english": "explorer", "spanish": "explorador", "definition": "a person who travels to unknown places" }
-],
-    list15: [
-        { "english": "example", "spanish": "ejemplo", "definition": "a model or pattern to follow" },
-        { "english": "incomplete", "spanish": "incompleto", "definition": "not finished or whole" },
-        { "english": "enable", "spanish": "habilitar", "definition": "to make possible or allow" },
-        { "english": "exact", "spanish": "exacto", "definition": "precise or correct" },
-        { "english": "enforced", "spanish": "aplicado", "definition": "made to be obeyed" },
-        { "english": "infield", "spanish": "campo interior", "definition": "the central part of a sports field" }
-    ],
-    list11: [
-            { english: "lifeguard", spanish: "salvavidas", definition: "a person who watches over swimmers" },
-            { english: "themselves", spanish: "ellos mismos", definition: "refers to a group of people performing actions on their own" },
-            { english: "however", spanish: "sin embargo", definition: "used to introduce a statement that contrasts with or contradicts the previous one" },
-            { english: "warm-blooded", spanish: "de sangre caliente", definition: "having a body temperature that is regulated internally" },
-            { english: "everlasting", spanish: "eterno", definition: "lasting forever, without end" }
-        ],
-    list10: [ // New list of words with short definitions
-            { english: "completing", spanish: "completando", definition: "finishing a task" },
-            { english: "risen", spanish: "elevado", definition: "gone up or increased" },
-            { english: "excelled", spanish: "destacado", definition: "performed very well" },
-            { english: "families", spanish: "familias", definition: "groups of related individuals" },
-            { english: "donating", spanish: "donando", definition: "giving as a gift" }
-        ],
-    list9: [ // New list with short definitions
-        { english: "partner", spanish: "compañero", definition: "a person who shares in an activity" },
-        { english: "explore", spanish: "explorar", definition: "to travel for discovery" },
-        { english: "fabric", spanish: "tela", definition: "material made by weaving fibers" },
-        { english: "welcome", spanish: "bienvenido", definition: "a friendly greeting" },
-        { english: "arctic", spanish: "ártico", definition: "related to the North Pole" },
-        { english: "textiles", spanish: "textiles", definition: "woven fabrics" }
-        ],
-    list8: [ // New word list with short definitions
-        { english: "solo", spanish: "solo", definition: "done alone" },
-        { english: "camel", spanish: "camello", definition: "a desert animal" },
-        { english: "solid", spanish: "sólido", definition: "firm and stable" },
-        { english: "season", spanish: "estación", definition: "time of the year" },
-        { english: "habit", spanish: "hábito", definition: "a regular practice" },
-        { english: "cocoa", spanish: "cacao", definition: "a bean used to make chocolate" }
-        ],
-    list7: [  // New word list with short sentences for beginners
-        { english: "menu", spanish: "menú", definition: "A list of food in a restaurant.", sentence: "The menu has many options." },
-        { english: "offer", spanish: "oferta", definition: "To give or provide something.", sentence: "He made an offer to help." },
-        { english: "talent", spanish: "talento", definition: "A natural ability to do something well.", sentence: "She has a talent for singing." },
-        { english: "gospel", spanish: "evangelio", definition: "A message or teaching of faith.", sentence: "They sang a gospel song in church." },
-        { english: "body", spanish: "cuerpo", definition: "The physical structure of a person or animal.", sentence: "He exercises to keep his body healthy." }
-    ],
 
-    list6: [  // Previous word list
-        { english: "sparrow", spanish: "gorrión", definition: "a small bird" },
-        { english: "cherish", spanish: "apreciar", definition: "to value or care for deeply" },
-        { english: "cherry", spanish: "cereza", definition: "a small, round, red fruit" },
-        { english: "aware", spanish: "consciente", definition: "having knowledge or awareness" },
-        { english: "armor", spanish: "armadura", definition: "protective covering worn in battle" },
-        { english: "narrate", spanish: "narrar", definition: "to tell a story" }
-    ],
-    
-    list5: [
-        { english: 'Jewel', spanish: 'joya', definition: 'an ornament of precious metal; gem)' },
-        { english: 'Loyal', spanish: 'leal', definition: 'faithful)' },
-        { english: 'Pronounce', spanish: 'pronunciar', definition: 'to declare)' },
-        { english: 'Purpose', spanish: 'propósito', definition: 'The result one hopes for in doing or making something; goal)' },
-        { english: 'Murmur', spanish: 'murmurar', definition: 'a low, soft, continuing sound)' },
-        { english: 'Virtue', spanish: 'virtud', definition: 'excellence in discerning right from wrong and choosing to do right)' },
-        { english: 'Herbal', spanish: 'herbal', definition: 'made of herbs)' }
-    ],
-    
-    list4: [
-        { english: 'Jewel', spanish: 'joya', definition: 'She wore a beautiful jewel around her neck. (Ella llevaba una hermosa joya en su cuello.)' },
-        { english: 'Loyal', spanish: 'leal', definition: 'My dog is very loyal and always stays by my side. (Mi perro es muy leal y siempre está a mi lado.)' },
-        { english: 'Chowder', spanish: 'sopa espesa', definition: 'I had a delicious chowder for lunch today. (Hoy almorcé una deliciosa sopa espesa.)' },
-        { english: 'Awesome', spanish: 'impresionante', definition: 'The view from the mountain was absolutely awesome. (La vista desde la montaña era absolutamente impresionante.)' },
-        { english: 'Destroy', spanish: 'destruir', definition: 'The storm will destroy the crops if it doesn’t stop. (La tormenta destruirá los cultivos si no se detiene.)' },
-        { english: 'Awkward', spanish: 'incómodo', definition: 'The silence during the meeting was really awkward. (El silencio durante la reunión fue realmente incómodo.)' }
-    ]
-};
+    let wordLists = {};
+
+    // Fetch the lists from JSON and populate the select options
+    fetch('menu_wordlists.json')
+        .then(resp => resp.json())
+        .then(data => {
+            wordLists = data;
+            wordListSelect.innerHTML = '';
+            Object.keys(wordLists).forEach(key => {
+                const option = document.createElement('option');
+                option.value = key;
+                option.textContent = key;
+                wordListSelect.appendChild(option);
+            });
+        })
+        .catch(err => console.error('Error loading word lists:', err));
+
 
 
     // Get references to elements

--- a/menu_wordlists.json
+++ b/menu_wordlists.json
@@ -1,0 +1,90 @@
+{
+  "list29": [
+    { "english": "distance", "spanish": "distancia", "definition": "the amount of space between two points" },
+    { "english": "distant", "spanish": "distante", "definition": "far away in space or time" },
+    { "english": "obedience", "spanish": "obediencia", "definition": "the act of following orders or rules" },
+    { "english": "obedient", "spanish": "obediente", "definition": "willing to follow commands or authority" },
+    { "english": "diligence", "spanish": "diligencia", "definition": "careful and persistent work or effort" },
+    { "english": "diligent", "spanish": "diligente", "definition": "showing careful and persistent effort" },
+    { "english": "importance", "spanish": "importancia", "definition": "the state or fact of being significant or valuable" },
+    { "english": "important", "spanish": "importante", "definition": "having great value or significance" }
+  ],
+  "list17": [
+    { "english": "closely", "spanish": "de cerca", "definition": "in a close manner or with attention" },
+    { "english": "delightful", "spanish": "delicioso", "definition": "giving great pleasure or happiness" },
+    { "english": "beginner", "spanish": "principiante", "definition": "someone who is just starting to learn or do something" },
+    { "english": "narrator", "spanish": "narrador", "definition": "a person who tells a story" },
+    { "english": "cheerful", "spanish": "alegre", "definition": "having a happy and positive attitude" },
+    { "english": "explorer", "spanish": "explorador", "definition": "a person who travels to unknown places" }
+  ],
+  "list15": [
+    { "english": "example", "spanish": "ejemplo", "definition": "a model or pattern to follow" },
+    { "english": "incomplete", "spanish": "incompleto", "definition": "not finished or whole" },
+    { "english": "enable", "spanish": "habilitar", "definition": "to make possible or allow" },
+    { "english": "exact", "spanish": "exacto", "definition": "precise or correct" },
+    { "english": "enforced", "spanish": "aplicado", "definition": "made to be obeyed" },
+    { "english": "infield", "spanish": "campo interior", "definition": "the central part of a sports field" }
+  ],
+  "list11": [
+    { "english": "lifeguard", "spanish": "salvavidas", "definition": "a person who watches over swimmers" },
+    { "english": "themselves", "spanish": "ellos mismos", "definition": "refers to a group of people performing actions on their own" },
+    { "english": "however", "spanish": "sin embargo", "definition": "used to introduce a statement that contrasts with or contradicts the previous one" },
+    { "english": "warm-blooded", "spanish": "de sangre caliente", "definition": "having a body temperature that is regulated internally" },
+    { "english": "everlasting", "spanish": "eterno", "definition": "lasting forever, without end" }
+  ],
+  "list10": [
+    { "english": "completing", "spanish": "completando", "definition": "finishing a task" },
+    { "english": "risen", "spanish": "elevado", "definition": "gone up or increased" },
+    { "english": "excelled", "spanish": "destacado", "definition": "performed very well" },
+    { "english": "families", "spanish": "familias", "definition": "groups of related individuals" },
+    { "english": "donating", "spanish": "donando", "definition": "giving as a gift" }
+  ],
+  "list9": [
+    { "english": "partner", "spanish": "compañero", "definition": "a person who shares in an activity" },
+    { "english": "explore", "spanish": "explorar", "definition": "to travel for discovery" },
+    { "english": "fabric", "spanish": "tela", "definition": "material made by weaving fibers" },
+    { "english": "welcome", "spanish": "bienvenido", "definition": "a friendly greeting" },
+    { "english": "arctic", "spanish": "ártico", "definition": "related to the North Pole" },
+    { "english": "textiles", "spanish": "textiles", "definition": "woven fabrics" }
+  ],
+  "list8": [
+    { "english": "solo", "spanish": "solo", "definition": "done alone" },
+    { "english": "camel", "spanish": "camello", "definition": "a desert animal" },
+    { "english": "solid", "spanish": "sólido", "definition": "firm and stable" },
+    { "english": "season", "spanish": "estación", "definition": "time of the year" },
+    { "english": "habit", "spanish": "hábito", "definition": "a regular practice" },
+    { "english": "cocoa", "spanish": "cacao", "definition": "a bean used to make chocolate" }
+  ],
+  "list7": [
+    { "english": "menu", "spanish": "menú", "definition": "A list of food in a restaurant.", "sentence": "The menu has many options." },
+    { "english": "offer", "spanish": "oferta", "definition": "To give or provide something.", "sentence": "He made an offer to help." },
+    { "english": "talent", "spanish": "talento", "definition": "A natural ability to do something well.", "sentence": "She has a talent for singing." },
+    { "english": "gospel", "spanish": "evangelio", "definition": "A message or teaching of faith.", "sentence": "They sang a gospel song in church." },
+    { "english": "body", "spanish": "cuerpo", "definition": "The physical structure of a person or animal.", "sentence": "He exercises to keep his body healthy." }
+  ],
+  "list6": [
+    { "english": "sparrow", "spanish": "gorrión", "definition": "a small bird" },
+    { "english": "cherish", "spanish": "apreciar", "definition": "to value or care for deeply" },
+    { "english": "cherry", "spanish": "cereza", "definition": "a small, round, red fruit" },
+    { "english": "aware", "spanish": "consciente", "definition": "having knowledge or awareness" },
+    { "english": "armor", "spanish": "armadura", "definition": "protective covering worn in battle" },
+    { "english": "narrate", "spanish": "narrar", "definition": "to tell a story" }
+  ],
+  "list5": [
+    { "english": "Jewel", "spanish": "joya", "definition": "an ornament of precious metal; gem)" },
+    { "english": "Loyal", "spanish": "leal", "definition": "faithful)" },
+    { "english": "Pronounce", "spanish": "pronunciar", "definition": "to declare)" },
+    { "english": "Purpose", "spanish": "propósito", "definition": "The result one hopes for in doing or making something; goal)" },
+    { "english": "Murmur", "spanish": "murmurar", "definition": "a low, soft, continuing sound)" },
+    { "english": "Virtue", "spanish": "virtud", "definition": "excellence in discerning right from wrong and choosing to do right)" },
+    { "english": "Herbal", "spanish": "herbal", "definition": "made of herbs)" }
+  ],
+  "list4": [
+    { "english": "Jewel", "spanish": "joya", "definition": "She wore a beautiful jewel around her neck. (Ella llevaba una hermosa joya en su cuello.)" },
+    { "english": "Loyal", "spanish": "leal", "definition": "My dog is very loyal and always stays by my side. (Mi perro es muy leal y siempre está a mi lado.)" },
+    { "english": "Chowder", "spanish": "sopa espesa", "definition": "I had a delicious chowder for lunch today. (Hoy almorcé una deliciosa sopa espesa.)" },
+    { "english": "Awesome", "spanish": "impresionante", "definition": "The view from the mountain was absolutely awesome. (La vista desde la montaña era absolutamente impresionante.)" },
+    { "english": "Destroy", "spanish": "destruir", "definition": "The storm will destroy the crops if it doesn’t stop. (La tormenta destruirá los cultivos si no se detiene.)" },
+    { "english": "Awkward", "spanish": "incómodo", "definition": "The silence during the meeting was really awkward. (El silencio durante la reunión fue realmente incómodo.)" }
+  ]
+}


### PR DESCRIPTION
## Summary
- load menu word lists from a new `menu_wordlists.json`
- dynamically populate the menu dropdown with the loaded lists

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478ffabbac8331bdc3225275d68bd5