### PR TITLE
Add flip and fade animations

### DIFF
--- a/challenge3.js
+++ b/challenge3.js
@@ -73,7 +73,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const randomIndex = Math.floor(Math.random() * words.length);
         currentWord = words[randomIndex];
+        wordDisplay.classList.remove('fade-in');
+        void wordDisplay.offsetWidth;
         wordDisplay.innerText = currentWord.spanish; // Display the word in Spanish
+        wordDisplay.classList.add('fade-in');
         translationInput.value = '';
         timeLeft = 25; // Reset the timer
     }

--- a/challenge4.css
+++ b/challenge4.css
@@ -187,3 +187,12 @@ h1 {
     background-color: red;
     transition: background-color 0.3s ease;
 }
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.fade-in {
+    animation: fadeIn 0.5s ease-in-out;
+}

--- a/challenge4.js
+++ b/challenge4.js
@@ -32,7 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (words.length > 0) {
             const randomIndex = Math.floor(Math.random() * words.length);
             currentWord = words[randomIndex];
+            spanishWordElem.classList.remove('fade-in');
+            void spanishWordElem.offsetWidth;
             spanishWordElem.innerText = currentWord.spanish;
+            spanishWordElem.classList.add('fade-in');
             feedback.innerText = '';
             submitButton.disabled = false;  // Re-enable the button in case it was disabled
         }

--- a/challenge5.css
+++ b/challenge5.css
@@ -28,15 +28,21 @@
     font-size: 18px;
     border-radius: 8px;
     cursor: pointer;
-    transition: transform 0.3s;
+    transition: transform 0.6s;
     position: relative;
-    backface-visibility: hidden;
 }
 
 /* Card when flipped */
 .card.flipped {
     background-color: #fff;
     color: #333;
+    animation: flip 0.6s forwards;
+}
+
+@keyframes flip {
+    0% { transform: rotateY(0); }
+    50% { transform: rotateY(180deg); }
+    100% { transform: rotateY(360deg); }
 }
 
 /* Hidden matched cards */

--- a/styles.css
+++ b/styles.css
@@ -182,3 +182,12 @@ h1 {
     background-color: #555; /* Darken button on hover */
 }
 
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.fade-in {
+    animation: fadeIn 0.5s ease-in-out;
+}
+


### PR DESCRIPTION
## Summary
- enhance Challenge 5 cards with a flip animation
- fade in the next word for Challenges 3 and 4
- add shared fade-in animation helpers

## Testing
- `npm install`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847986abf20833195377251731f96bf